### PR TITLE
Small change to fix yum-plugin-priorities interaction...

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -262,6 +262,7 @@ def init_hook(conduit):
             new_repo.enablegroups = repo.enablegroups
             new_repo.key_id = repo.key_id
             new_repo.secret_key = repo.secret_key
+            new_repo.priority = repo.priority
 
             repos.delete(repo.id)
             repos.add(new_repo)


### PR DESCRIPTION
The re-instantiation of the repo object is breaking the yum-priorities p...lugin; we, and I'm sure others, often use your awesome yum s3 plugin for custom repos (thanks much!)....but if we don't have access to config.RepoConf.priority the s3 repos get set to priority of 99 :(
