### PR TITLE
honoring "enabled" flag

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -239,6 +239,7 @@ plugin_type = TYPE_CORE
 def config_hook(conduit):
     logger = logging.getLogger("yum.verbose.main")
     config.RepoConf.s3_enabled = config.BoolOption(False)
+    config.RepoConf.enabled = config.BoolOption(False)
     config.RepoConf.key_id = config.Option() or conduit.confString('main', 'aws_access_key_id')
     config.RepoConf.secret_key = config.Option() or conduit.confString('main', 'aws_secret_access_key')
 


### PR DESCRIPTION
when your .repo file has the enabled flag (not to be confused with the s3_enabled flag), yum would ignore it. This fixes that bug. 
