### PR TITLE
Turn off Boto validation of the bucket. Allows access without ListBucket permissions.

### DIFF
--- a/s3.py
+++ b/s3.py
@@ -160,7 +160,7 @@ def createBotoGrabber():
 
         def _key(self, key_name):
             self.logger.debug("_key(%s)" % key_name)
-            bucket = self.s3.get_bucket(self.bucket_name)
+            bucket = self.s3.get_bucket(self.bucket_name, validate=False)
 
             return bucket.get_key(key_name)
 

--- a/spec
+++ b/spec
@@ -1,5 +1,5 @@
 Name:		yum-s3
-Version:	0.2.3
+Version:	0.2.4
 Release:	1
 Summary:	Amazon S3 plugin for yum.
 


### PR DESCRIPTION
Not needing ListBucket permissions simplifies setting up access to the bucket.
